### PR TITLE
Update name to SimpleMainMenu Lib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ServerMainMenu-Lib Jar
+          name: SimpleMainMenu-Lib Jar
           path: build/libs/*.jar

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ServerMainMenu-Lib
+# SimpleMainMenu-Lib
 
-Provides an easy-to-use system for customizing the main menu around a server.
+Provides an easy-to-use system for customizing the main menu around a server or other simple menu theme.
 
-To get started using the library, check out the [Getting Started Guide](https://github.com/MoSadie/ServerMainMenu-Lib/wiki/Getting-Started)!
+To get started using the library, check out the [Getting Started Guide](https://github.com/MoSadie/SimpleMainMenu-Lib/wiki/Getting-Started)!
 
 ## Features:
 
@@ -16,7 +16,7 @@ Supports adding one or more panoramas to the main menu. There are pre-made optio
 
 ### Quick-join button
 
-One-click button to automatically connect to a specified server.
+One-click button to automatically connect to a specified server. (Or world, or whatever you want to code! There's easy pre-made options for most uses!)
 
 ### Client Configuration
 
@@ -25,4 +25,4 @@ Multiple options on the client side to customize the main menu and override them
 
 ## Known Mod Compatibility:
 - [Replay Mod](https://replaymod.com/)'s button appears correctly.
-- If you encounter an issue or have any suggestions, [please let me know](https://github.com/MoSadie/ServerMainMenu-Lib/issues)!
+- If you encounter an issue or have any suggestions, [please let me know](https://github.com/MoSadie/SimpleMainMenu-Lib/issues)!

--- a/build.gradle
+++ b/build.gradle
@@ -80,11 +80,12 @@ java {
     if (System.getenv("CI") == null) {
         withSourcesJar()
     }
+    //withJavadocJar()
 }
 
 jar {
     from("LICENSE") {
-        rename { "${it}_${project.archivesBaseName}" }
+        rename { "${it}_${project.archiveBaseName}" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ fabric_api_version=0.141.2+1.21.11
 # Mod Properties
 mod_version=2.1.0
 maven_group=com.mosadie
-archivesBaseName=servermainmenu-lib
+archiveBaseName=simplemainmenu-lib
 
 # Dependency Versions (easy to check on https://linkie.shedaniel.dev/dependencies)
 cloth_config_version=21.11.153

--- a/src/main/generated/.cache/7955b7db2470027ab5a3117dfaf8494ab0593d2f
+++ b/src/main/generated/.cache/7955b7db2470027ab5a3117dfaf8494ab0593d2f
@@ -1,0 +1,2 @@
+// 1.21.11	-999999999-01-01T00:00:00	SimpleMainMenu Lib/Language (en_us)
+4fa352432b2444e1b823fef66df46fe8b1994bf1 assets/smm-lib/lang/en_us.json

--- a/src/main/generated/.cache/f0dd3cbca1c68b4679a5d395aa3aad3bc9c2b1a5
+++ b/src/main/generated/.cache/f0dd3cbca1c68b4679a5d395aa3aad3bc9c2b1a5
@@ -1,2 +1,0 @@
-// 1.20.2	2023-12-04T20:33:41.3942378	ServerMainMenu Lib/Language (en_us)
-08b1e4820114e2cc60c7f6a40b6a68f3240b213a assets\smm-lib\lang\en_us.json

--- a/src/main/generated/assets/smm-lib/lang/en_us.json
+++ b/src/main/generated/assets/smm-lib/lang/en_us.json
@@ -1,10 +1,10 @@
 {
   "text.autoconfig.smm-lib.option.quickJoinButtonOptions": "Quick Join Button Settings",
-  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonDestinationOverride": "Quick Join Button Server Address / World Folder",
-  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonNameOverride": "Quick Join Button Server Name",
+  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonDestinationOverride": "Server Address / World Folder",
+  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonNameOverride": "Button Server Name",
   "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonNameOverride.@Tooltip": "Mainly used by mods such as ReplayMod to track what server you were on. Unused in World mode.",
-  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonTextOverride": "Quick Join Button Text",
-  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonType": "Quick Join Button Destination Type",
+  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonTextOverride": "Button Text",
+  "text.autoconfig.smm-lib.option.quickJoinButtonOptions.buttonType": "Destination Type",
   "text.autoconfig.smm-lib.option.quickJoinButtonOptions.overrideQuickJoinButton": "Override Quick Join Button?",
   "text.autoconfig.smm-lib.option.splashOptions": "Splash Message Settings",
   "text.autoconfig.smm-lib.option.splashOptions.overrideSplash": "Override Splash Text?",
@@ -19,7 +19,7 @@
   "text.autoconfig.smm-lib.option.visibilityOptions.multiplayer": "Show Multiplayer Button",
   "text.autoconfig.smm-lib.option.visibilityOptions.quickJoin": "Show Quick Join Button",
   "text.autoconfig.smm-lib.option.visibilityOptions.singleplayer": "Show Singleplayer Button",
-  "text.autoconfig.smm-lib.title": "ServerMainMenu Lib Settings",
+  "text.autoconfig.smm-lib.title": "SimpleMainMenu Lib Settings",
   "text.smm-lib.error.worldnotfound.body": "World %s not found! Make sure it has been created first.",
   "text.smm-lib.error.worldnotfound.title": "World not found!",
   "text.smmlib.normaltheme.joinserver": "Join the server!"

--- a/src/main/java/com/mosadie/simplemainmenu/api/MenuTheme.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/MenuTheme.java
@@ -1,7 +1,5 @@
-package com.mosadie.servermainmenu.api;
+package com.mosadie.simplemainmenu.api;
 
-import net.minecraft.client.network.ServerInfo;
-import net.minecraft.resource.Resource;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 

--- a/src/main/java/com/mosadie/simplemainmenu/api/MenuTheme.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/MenuTheme.java
@@ -6,10 +6,6 @@ import net.minecraft.util.Identifier;
 public interface MenuTheme {
     String getId();
     Identifier getPanorama();
-    @Deprecated
-    default String getSplashText() {
-        return null;
-    }
     Text getSplashAsText();
 
     boolean rollOdds();

--- a/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
@@ -1,7 +1,5 @@
-package com.mosadie.servermainmenu.api;
+package com.mosadie.simplemainmenu.api;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ServerInfo;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 

--- a/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
@@ -19,7 +19,7 @@ public class NormalTheme implements MenuTheme{
 
     @Override
     public Text getSplashAsText() {
-        return Text.literal("Just a normal menu...");
+        return Text.literal("Just a normal menu...").setStyle(Util.SPLASH_TEXT_STYLE);
     }
 
     @Override

--- a/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
@@ -20,8 +20,8 @@ public class NormalTheme implements MenuTheme{
     @Override
     public SplashText getSplashText() {
         return SplashText.builder()
-                .addLine("Just a normal menu...")
-                .addLine("for now!")
+                .addLine("Just a normal menu...") // Example of using addLine with a String...
+                .addLine(Text.literal("for now!").setStyle(Util.SPLASH_TEXT_STYLE)) // Or using a Text object with styling!
                 .build();
     }
 

--- a/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/NormalTheme.java
@@ -21,7 +21,7 @@ public class NormalTheme implements MenuTheme{
     public SplashText getSplashText() {
         return SplashText.builder()
                 .addLine("Just a normal menu...")
-                .addLine("yay!")
+                .addLine("for now!")
                 .build();
     }
 

--- a/src/main/java/com/mosadie/simplemainmenu/api/SplashText.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/SplashText.java
@@ -1,4 +1,4 @@
-package com.mosadie.servermainmenu.api;
+package com.mosadie.simplemainmenu.api;
 
 import net.minecraft.text.Text;
 

--- a/src/main/java/com/mosadie/simplemainmenu/api/Util.java
+++ b/src/main/java/com/mosadie/simplemainmenu/api/Util.java
@@ -1,8 +1,7 @@
-package com.mosadie.servermainmenu.api;
+package com.mosadie.simplemainmenu.api;
 
-import com.mosadie.servermainmenu.client.ServerMainMenuLibClient;
+import com.mosadie.simplemainmenu.client.SimpleMainMenuLibClient;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.MessageScreen;
 import net.minecraft.client.gui.screen.NoticeScreen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
@@ -100,7 +99,7 @@ public class Util {
         MinecraftClient.getInstance().send(() -> {
             leaveIfNeeded();
 
-            ServerMainMenuLibClient.LOGGER.info("Connecting to " + server.address);
+            SimpleMainMenuLibClient.LOGGER.info("Connecting to " + server.address);
 
             // Connect to server
 
@@ -113,13 +112,13 @@ public class Util {
             if (MinecraftClient.getInstance().getLevelStorage().levelExists(worldName)) {
                 leaveIfNeeded();
 
-                ServerMainMenuLibClient.LOGGER.info("Loading world...");
+                SimpleMainMenuLibClient.LOGGER.info("Loading world...");
                 MinecraftClient.getInstance().createIntegratedServerLoader().start(worldName, () -> {
-                    ServerMainMenuLibClient.LOGGER.info("World load cancelled.");
+                    SimpleMainMenuLibClient.LOGGER.info("World load cancelled.");
                     MinecraftClient.getInstance().setScreen(new TitleScreen());
                 });
             } else {
-                ServerMainMenuLibClient.LOGGER.warn("World " + worldName + " does not exist!");
+                SimpleMainMenuLibClient.LOGGER.warn("World " + worldName + " does not exist!");
                 if (MinecraftClient.getInstance().world == null)
                     MinecraftClient.getInstance().setScreen(new NoticeScreen(() -> MinecraftClient.getInstance().setScreen(new TitleScreen()), Text.translatable("text.smm-lib.error.worldnotfound.title"), Text.translatable("text.smm-lib.error.worldnotfound.body", worldName), ScreenTexts.TO_TITLE, true));
             }
@@ -131,7 +130,7 @@ public class Util {
      */
     private static void leaveIfNeeded() {
         if (MinecraftClient.getInstance().world != null) {
-            ServerMainMenuLibClient.LOGGER.info("Disconnecting from world...");
+            SimpleMainMenuLibClient.LOGGER.info("Disconnecting from world...");
 
             MinecraftClient.getInstance().world.disconnect(Text.translatable("menu.disconnect"));
             MinecraftClient.getInstance().disconnectWithProgressScreen();

--- a/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibClient.java
+++ b/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibClient.java
@@ -83,9 +83,7 @@ public class SimpleMainMenuLibClient implements ClientModInitializer {
         if (config != null && config.splashOptions.overrideSplash) {
             return Text.of(config.splashOptions.overrideSplashText);
         }
-
-        // Fallback in case of older themes that still use the deprecated getSplashText method.
-        if (getTheme().getSplashText() != null) return Text.literal(getTheme().getSplashText()).setStyle(Util.SPLASH_TEXT_STYLE);
+        
         return getTheme().getSplashAsText();
     }
 

--- a/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibClient.java
+++ b/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibClient.java
@@ -1,8 +1,8 @@
-package com.mosadie.servermainmenu.client;
+package com.mosadie.simplemainmenu.client;
 
-import com.mosadie.servermainmenu.api.MenuTheme;
-import com.mosadie.servermainmenu.api.NormalTheme;
-import com.mosadie.servermainmenu.api.Util;
+import com.mosadie.simplemainmenu.api.MenuTheme;
+import com.mosadie.simplemainmenu.api.NormalTheme;
+import com.mosadie.simplemainmenu.api.Util;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.ConfigHolder;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @net.fabricmc.api.Environment(net.fabricmc.api.EnvType.CLIENT)
-public class ServerMainMenuLibClient implements ClientModInitializer {
+public class SimpleMainMenuLibClient implements ClientModInitializer {
 
     public static final String MOD_ID = "smm-lib";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
@@ -76,7 +76,7 @@ public class ServerMainMenuLibClient implements ClientModInitializer {
         return menuTheme;
     }
 
-    private static ServerMainMenuLibConfig config;
+    private static SimpleMainMenuLibConfig config;
 
     @SuppressWarnings("deprecation")
     public static Text getSplashText() {
@@ -84,7 +84,7 @@ public class ServerMainMenuLibClient implements ClientModInitializer {
             return Text.of(config.splashOptions.overrideSplashText);
         }
 
-        // Should still work with old mods that don't implement the asText method I hope...
+        // Fallback in case of older themes that still use the deprecated getSplashText method.
         if (getTheme().getSplashText() != null) return Text.literal(getTheme().getSplashText()).setStyle(Util.SPLASH_TEXT_STYLE);
         return getTheme().getSplashAsText();
     }
@@ -110,32 +110,32 @@ public class ServerMainMenuLibClient implements ClientModInitializer {
     }
 
     public static boolean isSingleplayerVisible() {
-        if (config != null && config.visibilityOptions.singleplayer != ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
-            return config.visibilityOptions.singleplayer == ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
+        if (config != null && config.visibilityOptions.singleplayer != SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
+            return config.visibilityOptions.singleplayer == SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
         }
 
         return getTheme().isSingleplayerVisible();
     }
 
     public static boolean isMultiplayerVisible() {
-        if (config != null && config.visibilityOptions.multiplayer != ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
-            return config.visibilityOptions.multiplayer == ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
+        if (config != null && config.visibilityOptions.multiplayer != SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
+            return config.visibilityOptions.multiplayer == SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
         }
 
         return getTheme().isMultiplayerVisible();
     }
 
     public static boolean isModsVisible() {
-        if (config != null && config.visibilityOptions.mods != ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
-            return config.visibilityOptions.mods == ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
+        if (config != null && config.visibilityOptions.mods != SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
+            return config.visibilityOptions.mods == SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
         }
 
         return getTheme().isModsVisible();
     }
 
     public static boolean isQuickJoinVisible() {
-        if (config != null && config.visibilityOptions.quickJoin != ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
-            return config.visibilityOptions.quickJoin == ServerMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
+        if (config != null && config.visibilityOptions.quickJoin != SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.DEFAULT) {
+            return config.visibilityOptions.quickJoin == SimpleMainMenuLibConfig.VisibilityOptions.VisibilityState.SHOW;
         }
 
         return getTheme().isQuickJoinVisible();
@@ -147,19 +147,19 @@ public class ServerMainMenuLibClient implements ClientModInitializer {
 
         LOGGER.info("Configuring Config...");
 
-        AutoConfig.register(ServerMainMenuLibConfig.class, GsonConfigSerializer::new);
+        AutoConfig.register(SimpleMainMenuLibConfig.class, GsonConfigSerializer::new);
 
-        AutoConfig.getConfigHolder(ServerMainMenuLibConfig.class).registerSaveListener(ServerMainMenuLibClient::onConfigSave);
+        AutoConfig.getConfigHolder(SimpleMainMenuLibConfig.class).registerSaveListener(SimpleMainMenuLibClient::onConfigSave);
 
-        config = AutoConfig.getConfigHolder(ServerMainMenuLibConfig.class).getConfig();
+        config = AutoConfig.getConfigHolder(SimpleMainMenuLibConfig.class).getConfig();
 
         LOGGER.info("SimpleServerMenu-Lib Initialized!");
     }
 
-    private static ActionResult onConfigSave(ConfigHolder<ServerMainMenuLibConfig> islandMenuConfigConfigHolder, ServerMainMenuLibConfig serverMainMenuLibConfig) {
+    private static ActionResult onConfigSave(ConfigHolder<SimpleMainMenuLibConfig> simpleMainMenuLibConfigConfigHolder, SimpleMainMenuLibConfig simpleMainMenuLibConfig) {
         LOGGER.info("Updating config!");
 
-        config = serverMainMenuLibConfig;
+        config = simpleMainMenuLibConfig;
 
         menuTheme = selectTheme();
 

--- a/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibConfig.java
+++ b/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibConfig.java
@@ -1,11 +1,11 @@
-package com.mosadie.servermainmenu.client;
+package com.mosadie.simplemainmenu.client;
 
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
-@Config(name = ServerMainMenuLibClient.MOD_ID)
-public class ServerMainMenuLibConfig implements ConfigData {
+@Config(name = SimpleMainMenuLibClient.MOD_ID)
+public class SimpleMainMenuLibConfig implements ConfigData {
 
     @ConfigEntry.Gui.CollapsibleObject
     QuickJoinButtonOptions quickJoinButtonOptions = new QuickJoinButtonOptions();

--- a/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibModMenuIntegration.java
+++ b/src/main/java/com/mosadie/simplemainmenu/client/SimpleMainMenuLibModMenuIntegration.java
@@ -1,12 +1,12 @@
-package com.mosadie.servermainmenu.client;
+package com.mosadie.simplemainmenu.client;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import me.shedaniel.autoconfig.AutoConfigClient;
 
-public class ServerMainMenuLibModMenuIntegration implements ModMenuApi {
+public class SimpleMainMenuLibModMenuIntegration implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return parent -> AutoConfigClient.getConfigScreen(ServerMainMenuLibConfig.class, parent).get();
+        return parent -> AutoConfigClient.getConfigScreen(SimpleMainMenuLibConfig.class, parent).get();
     }
 }

--- a/src/main/java/com/mosadie/simplemainmenu/client/data/SimpleMainMenuLibDataGen.java
+++ b/src/main/java/com/mosadie/simplemainmenu/client/data/SimpleMainMenuLibDataGen.java
@@ -1,12 +1,12 @@
-package com.mosadie.servermainmenu.client.data;
+package com.mosadie.simplemainmenu.client.data;
 
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 
-public class ServerMainMenuLibDataGen implements DataGeneratorEntrypoint {
+public class SimpleMainMenuLibDataGen implements DataGeneratorEntrypoint {
     @Override
     public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
         FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
-        pack.addProvider(ServerMainMenuLibEnLangProvider::new);
+        pack.addProvider(SimpleMainMenuLibEnLangProvider::new);
     }
 }

--- a/src/main/java/com/mosadie/simplemainmenu/client/data/SimpleMainMenuLibEnLangProvider.java
+++ b/src/main/java/com/mosadie/simplemainmenu/client/data/SimpleMainMenuLibEnLangProvider.java
@@ -1,4 +1,4 @@
-package com.mosadie.servermainmenu.client.data;
+package com.mosadie.simplemainmenu.client.data;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider;
@@ -6,8 +6,8 @@ import net.minecraft.registry.RegistryWrapper;
 
 import java.util.concurrent.CompletableFuture;
 
-public class ServerMainMenuLibEnLangProvider extends FabricLanguageProvider {
-    protected ServerMainMenuLibEnLangProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup) {
+public class SimpleMainMenuLibEnLangProvider extends FabricLanguageProvider {
+    protected SimpleMainMenuLibEnLangProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup) {
         super(dataOutput, "en_us", registryLookup);
     }
 
@@ -15,7 +15,7 @@ public class ServerMainMenuLibEnLangProvider extends FabricLanguageProvider {
     public void generateTranslations(RegistryWrapper.WrapperLookup wrapperLookup, TranslationBuilder translationBuilder) {
         translationBuilder.add("text.smmlib.normaltheme.joinserver", "Join the server!");
 
-        translationBuilder.add("text.autoconfig.smm-lib.title", "ServerMainMenu Lib Settings");
+        translationBuilder.add("text.autoconfig.smm-lib.title", "SimpleMainMenu Lib Settings");
 
         translationBuilder.add("text.autoconfig.smm-lib.option.quickJoinButtonOptions", "Quick Join Button Settings");
 

--- a/src/main/java/com/mosadie/simplemainmenu/duck/MultilineSplashTextRenderer.java
+++ b/src/main/java/com/mosadie/simplemainmenu/duck/MultilineSplashTextRenderer.java
@@ -1,4 +1,4 @@
-package com.mosadie.servermainmenu.duck;
+package com.mosadie.simplemainmenu.duck;
 
 import net.minecraft.text.Text;
 

--- a/src/main/java/com/mosadie/simplemainmenu/mixin/IdentifierMixin.java
+++ b/src/main/java/com/mosadie/simplemainmenu/mixin/IdentifierMixin.java
@@ -1,6 +1,6 @@
-package com.mosadie.servermainmenu.mixin;
+package com.mosadie.simplemainmenu.mixin;
 
-import com.mosadie.servermainmenu.client.ServerMainMenuLibClient;
+import com.mosadie.simplemainmenu.client.SimpleMainMenuLibClient;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -17,7 +17,7 @@ public class IdentifierMixin {
     public static Identifier ofVanilla(String path) {
         // If we are getting the background panorama texture, we want to return the custom panorama texture from the selected theme instead.
         if (path != null && path.equals("textures/gui/title/background/panorama")) {
-            return ServerMainMenuLibClient.getTheme().getPanorama();
+            return SimpleMainMenuLibClient.getTheme().getPanorama();
         }
 
         return Identifier.of("minecraft", path);

--- a/src/main/java/com/mosadie/simplemainmenu/mixin/SplashTextRendererMixin.java
+++ b/src/main/java/com/mosadie/simplemainmenu/mixin/SplashTextRendererMixin.java
@@ -1,8 +1,8 @@
-package com.mosadie.servermainmenu.mixin;
+package com.mosadie.simplemainmenu.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.mosadie.servermainmenu.duck.MultilineSplashTextRenderer;
+import com.mosadie.simplemainmenu.duck.MultilineSplashTextRenderer;
 import net.minecraft.client.font.Alignment;
 import net.minecraft.client.font.DrawnTextConsumer;
 import net.minecraft.client.font.TextRenderer;

--- a/src/main/java/com/mosadie/simplemainmenu/mixin/TitleScreenInvoker.java
+++ b/src/main/java/com/mosadie/simplemainmenu/mixin/TitleScreenInvoker.java
@@ -1,4 +1,4 @@
-package com.mosadie.servermainmenu.mixin;
+package com.mosadie.simplemainmenu.mixin;
 
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.text.Text;

--- a/src/main/java/com/mosadie/simplemainmenu/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/mosadie/simplemainmenu/mixin/TitleScreenMixin.java
@@ -1,6 +1,6 @@
-package com.mosadie.servermainmenu.mixin;
+package com.mosadie.simplemainmenu.mixin;
 
-import com.mosadie.servermainmenu.client.ServerMainMenuLibClient;
+import com.mosadie.simplemainmenu.client.SimpleMainMenuLibClient;
 import com.terraformersmc.modmenu.ModMenu;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import net.minecraft.client.MinecraftClient;
@@ -46,7 +46,7 @@ public abstract class TitleScreenMixin extends Screen {
     @Inject(method = "init()V", at = @At("HEAD"))
     private void injectSplashText(CallbackInfo info) {
         if (splashText == null)
-            this.splashText = new SplashTextRenderer(ServerMainMenuLibClient.getSplashText());
+            this.splashText = new SplashTextRenderer(SimpleMainMenuLibClient.getSplashText());
     }
 
     @Redirect(method = "init()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/TitleScreen;addNormalWidgets(II)I"))
@@ -55,15 +55,15 @@ public abstract class TitleScreenMixin extends Screen {
 
         int buttonCount = 0;
 
-        if (ServerMainMenuLibClient.isSingleplayerVisible()) buttonCount++;
-        if (ServerMainMenuLibClient.isMultiplayerVisible()) buttonCount++;
-        if (ServerMainMenuLibClient.isQuickJoinVisible()) buttonCount++;
+        if (SimpleMainMenuLibClient.isSingleplayerVisible()) buttonCount++;
+        if (SimpleMainMenuLibClient.isMultiplayerVisible()) buttonCount++;
+        if (SimpleMainMenuLibClient.isQuickJoinVisible()) buttonCount++;
 
         if (buttonCount == 1) {
             buttonYMulti = 1;
         }
 
-        if (ServerMainMenuLibClient.isSingleplayerVisible()) {
+        if (SimpleMainMenuLibClient.isSingleplayerVisible()) {
             ButtonWidget.Builder singlePlayerButtonWidgetBuilder = ButtonWidget.builder(Text.translatable("menu.singleplayer"), (button -> {
                         MinecraftClient.getInstance().setScreen(new SelectWorldScreen((self)));
                     }))
@@ -80,10 +80,10 @@ public abstract class TitleScreenMixin extends Screen {
 
         Tooltip tooltip = Tooltip.of(disabledText);
 
-        if (ServerMainMenuLibClient.isQuickJoinVisible()) {
+        if (SimpleMainMenuLibClient.isQuickJoinVisible()) {
 
-            ButtonWidget.Builder quickJoinButtonWidgetBuilder = ButtonWidget.builder(ServerMainMenuLibClient.getButtonText(), (button) -> {
-                ServerMainMenuLibClient.onQuickJoinClick();
+            ButtonWidget.Builder quickJoinButtonWidgetBuilder = ButtonWidget.builder(SimpleMainMenuLibClient.getButtonText(), (button) -> {
+                SimpleMainMenuLibClient.onQuickJoinClick();
             }).position(self.width / 2 - 100, y + (spacingY * buttonYMulti++)).size(200, 20);
 
             // Technically as of v2.0.0, this button can connect to things outside of multiplayer,
@@ -98,7 +98,7 @@ public abstract class TitleScreenMixin extends Screen {
             this.addDrawableChild(quickJoinButtonWidgetBuilder.build());
         }
 
-        if (ServerMainMenuLibClient.isMultiplayerVisible()) {
+        if (SimpleMainMenuLibClient.isMultiplayerVisible()) {
             ButtonWidget.Builder multiplayerButtonWidgetBuilder = ButtonWidget.builder(Text.translatable("menu.multiplayer"), button -> {
                 Screen screen = MinecraftClient.getInstance().options.skipMultiplayerWarning ? new MultiplayerScreen(self) : new MultiplayerWarningScreen(self);
                 MinecraftClient.getInstance().setScreen(screen);
@@ -113,7 +113,7 @@ public abstract class TitleScreenMixin extends Screen {
             this.addDrawableChild(multiplayerButtonWidget);
         }
 
-        if (ServerMainMenuLibClient.isModsVisible()) {
+        if (SimpleMainMenuLibClient.isModsVisible()) {
             ButtonWidget.Builder modsButtonWidgetBuilder = ButtonWidget.builder(ModMenu.createModsButtonText(true), button -> {
                 Screen modsScreen = ModMenuApi.createModsScreen(MinecraftClient.getInstance().currentScreen);
                 MinecraftClient.getInstance().setScreen(modsScreen);

--- a/src/main/java/com/mosadie/simplemainmenu/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/mosadie/simplemainmenu/mixin/TitleScreenMixin.java
@@ -47,7 +47,7 @@ public abstract class TitleScreenMixin extends Screen {
     @Inject(method = "init()V", at = @At("HEAD"))
     private void injectSplashText(CallbackInfo info) {
         if (splashText == null) {
-            Text[] splashes = ServerMainMenuLibClient.getSplashText();
+            Text[] splashes = SimpleMainMenuLibClient.getSplashText();
             // Still provide the first line or empty to avoid anything else that tries to use it crashing
             this.splashText = new SplashTextRenderer(splashes.length == 0 ? Text.of("") : splashes[0]);
             ((MultilineSplashTextRenderer) this.splashText).smm_lib$setMultilineText(splashes);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,32 +2,32 @@
   "schemaVersion": 1,
   "id": "smm-lib",
   "version": "${version}",
-  "name": "ServerMainMenu Lib",
+  "name": "SimpleMainMenu Lib",
   "description": "Library mod to customize the main menu.",
   "authors": [
     "MoSadie"
   ],
   "contact": {
     "homepage": "https://modrinth.com/mod/smm-lib",
-    "sources": "https://github.com/MoSadie/ServerMainMenu-Lib",
-    "issues": "https://github.com/MoSadie/ServerMainMenu-Lib/issues"
+    "sources": "https://github.com/MoSadie/SimpleMainMenu-Lib",
+    "issues": "https://github.com/MoSadie/SimpleMainMenu-Lib/issues"
   },
   "license": "LGPL-3.0",
   "icon": "assets/smm-lib/icon.png",
   "environment": "client",
   "entrypoints": {
     "client": [
-      "com.mosadie.servermainmenu.client.ServerMainMenuLibClient"
+      "com.mosadie.simplemainmenu.client.SimpleMainMenuLibClient"
     ],
     "fabric-datagen": [
-      "com.mosadie.servermainmenu.client.data.ServerMainMenuLibDataGen"
+      "com.mosadie.simplemainmenu.client.data.SimpleMainMenuLibDataGen"
     ],
     "modmenu": [
-      "com.mosadie.servermainmenu.client.ServerMainMenuLibModMenuIntegration"
+      "com.mosadie.simplemainmenu.client.SimpleMainMenuLibModMenuIntegration"
     ]
   },
   "mixins": [
-    "servermainmenu-lib.mixins.json"
+    "simplemainmenu-lib.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.18.0",

--- a/src/main/resources/simplemainmenu-lib.mixins.json
+++ b/src/main/resources/simplemainmenu-lib.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "minVersion": "0.8",
-  "package": "com.mosadie.servermainmenu.mixin",
+  "package": "com.mosadie.simplemainmenu.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],


### PR DESCRIPTION
This *WILL* break all previous themes, so also taking the chance to do a little bit of housekeeping. For example, removing the backwards compatibility added in v2.1.0 since all mods need to update anyway.